### PR TITLE
APIDef types support title and description for agreed-ui.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,8 @@ export type APIDef<
   RespHeader extends Headers,
   Resp extends ResponseDef<Status<number, string>, object>
 > = {
+  title?: string;
+  description?: string;
   request: RequestDef<P, ReqHeader, Q, M, ReqBody>;
   response: {
     headers?: RespHeader;


### PR DESCRIPTION
# About

Agreed can describe the title and description in the exports object (or json).
But, occur type error in title and description section.

# Example

```
export type API = APIDef<...>

const api: Array<API> = [
  {
    title: "hogepoge",  // error! but expected pass.
    description: "hogepoge", // error! but expected pass.
    request: {
      path: ["api", "greet"],
      method: "GET"
    },
    response: {
      status: 200,
      body: {
        message: "hello"
      },
    }
  },
]
```